### PR TITLE
Slightly change interface to allow more accurate testing

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -1,4 +1,3 @@
-import java.sql.Time;
 import java.util.concurrent.TimeUnit;
 
 public class Main {
@@ -10,22 +9,43 @@ public class Main {
             // Run the parallel timing tests.
             System.out.println("Running functional in parallel...");
             parallelTimingTests();
+
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
         } 
-        else if (args.length > 0 && args[0].equals("--allfunctional")) {
+        else if (args.length > 0 && args[0].equals("--all")) {
             System.out.println("Running functional sequentially...");
             sequentialTimingTests();
 
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
+
             System.out.println("Running functional in parallel...");
             parallelTimingTests();
+
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
+
+            System.out.println("Running imperative function...");
+            imperativeTimingTests();
+
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
         }
         else if (args.length > 0 && args[0].equals("--imperative")) {
             System.out.println("Running imperative function...");
             imperativeTimingTests();
+
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
         }
         else {
             // Run the sequential timing tests.
             System.out.println("Running functional sequentially...");
             sequentialTimingTests();
+
+            // Sleep to avoid overlap delay.
+            sleepOneMinute();
         }
     }
 
@@ -35,9 +55,9 @@ public class Main {
         long end = System.nanoTime();
 
         System.out.printf(
-                "Running in parallel took %d ms including the API delay and %d ms excluding it.%n",
-                TimeUnit.NANOSECONDS.toMillis(end - start),
-                TimeUnit.NANOSECONDS.toMillis(end - start - ONE_MINUTE_NANOSECONDS)
+            "Running in parallel took %d ms including the API delay and %d ms excluding it.%n",
+            TimeUnit.NANOSECONDS.toMillis(end - start),
+            TimeUnit.NANOSECONDS.toMillis(end - start - ONE_MINUTE_NANOSECONDS)
         );
     }
 
@@ -47,14 +67,13 @@ public class Main {
         long end = System.nanoTime();
 
         System.out.printf(
-                "Running sequentially took %d ms including the API delay and %d ms excluding it.%n",
-                TimeUnit.NANOSECONDS.toMillis(end - start),
-                TimeUnit.NANOSECONDS.toMillis(end - start - ONE_MINUTE_NANOSECONDS)
+            "Running sequentially took %d ms including the API delay and %d ms excluding it.%n",
+            TimeUnit.NANOSECONDS.toMillis(end - start),
+            TimeUnit.NANOSECONDS.toMillis(end - start - ONE_MINUTE_NANOSECONDS)
         );
     }
 
-    public static void imperativeTimingTests() {
-
+    private static void imperativeTimingTests() {
         long start = System.nanoTime();
         PickShareImperative.findHighPriced();
         long end = System.nanoTime();
@@ -64,5 +83,13 @@ public class Main {
             TimeUnit.NANOSECONDS.toMillis(end - start),
             TimeUnit.NANOSECONDS.toMillis(end - start - ONE_MINUTE_NANOSECONDS)
         );
+    }
+
+    private static void sleepOneMinute() {
+        try {
+            TimeUnit.MINUTES.sleep(1);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,21 @@ JC = javac
 all:
 	$(JC) *.java
 
-run: all
-	java Main
-
+# Run the parallel functional benchmarking test.
 run-parallel: all
 	java Main --parallel
+
+# Run the sequential functional benchmarking test.
+run-sequential: all
+	java Main
+
+# Run the imperative benchmarking test.
+run-imperative: all
+	java Main --imperative
+
+# Run all benchmarking tests.
+run-all: all
+	java Main --all
 
 clean:
 	rm -rf *.class

--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # ece421_project1
 
-## (private) link to the report
+## Running instructions
+
+Run all the benchmarking tests.
+```sh
+$ make run-all
+```
+
+Run just the sequential (non-concurrent) functional benchmarking test.
+```sh
+$ make run-sequential
+```
+
+Run just the parallel (concurrent) functional benchmarking test.
+```sh
+$ make run-parallel
+```
+
+Run just the imperative benchmarking test.
+```sh
+$ make run-imperative
+```
+
+## Private link to the report
 https://docs.google.com/document/d/1CsQg9MFQt-QFoCQZkKGNxPCNsR3nC8dI7YpGRyfnCrc/edit?usp=sharing


### PR DESCRIPTION
Previously, if we would try to run multiple tests, the API delay of one test would overlap with the new benchmarking test. These changes allow for all benchmarking tests to be run accurately by adding a one minute delay after each benchmarking test so that each benchmarking test can be started with an 5 available API requests.